### PR TITLE
v2, supporting hapi v17 and new goodies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
   - "8"
+  - "9"
+  - "node"
 
 after_script: "npm run coveralls"

--- a/API.md
+++ b/API.md
@@ -3,148 +3,60 @@
 ## `Toys`
 A container for a group of toys, each toy being a hapi utility.
 
-### `new Toys(server, [CustomPromise])`
-Creates an instance of toys specific to a hapi server `server`, and optionally a custom A+ promise constructor `CustomPromise`.
+### `new Toys(server)`
+Creates an instance of toys specific to a hapi server `server`;
 
 > **A note on usage**
 >
-> Each instance method, e.g. `toys.reacher()`, may also be used statically, e.g. `Toys.reacher()`.  The only difference between the static and instance methods is that some of the static methods have `server` or `CustomPromise` arguments that are not necessary when working with an instance.
+> Each instance method, e.g. `toys.reacher()`, may also be used statically, e.g. `Toys.reacher()`.  The only difference between the static and instance methods is that some of the static methods have or require `server` arguments that are not necessary when working with an instance.
 >
 > The docs below will document the static version of each toy, then note the signature of the instance version.
 
-### `Toys.withDefaults(defaults, [isNullOverride])`
-> As instance, `toys.withDefaults(defaults, [isNullOverride])`
+### `Toys.withRouteDefaults(defaults)`
+> As instance, `toys.withRouteDefaults(defaults)`
 
-Returns a function with signature `function(options)` that will apply `defaults` as defaults to the `options` object.  If `options` is an array of objects, it will apply the defaults to each item in the array. If `isNullOverride` is `true` then `null` values within `options` can override corresponding default values.
+Returns a function with signature `function(route)` that will apply `defaults` as defaults to the `route` [route configuration](https://github.com/hapijs/hapi/blob/master/API.md#server.route()) object.  It will shallow-merge any route `validate` and `bind` options to avoid inadvertently applying defaults to a Joi schema or other unfamiliar object.  If `route` is an array of routes, it will apply the defaults to each route in the array.
 
 ```js
-const defaultToGet = Toys.withDefaults({ method: 'get' });
+const defaultToGet = Toys.withRouteDefaults({ method: 'get' });
 
 server.route(
     defaultToGet([
         {
             path: '/',
-            handler: function (request, reply) {
-                reply('I was gotten');
-            }
+            handler: () => 'I was gotten'
         },
         {
             method: 'post',
             path: '/',
-            handler: function (request, reply) {
-                reply('I was posted');
-            }
+            handler: () => 'I was posted'
         }
     ])
 );
 ```
 
-### `Toys.handler(asyncHandler)`
-> As instance, `toys.handler(asyncHandler)`
-
-Returns a route handler function given `asyncHandler`, an `async function(request, reply)`, that will handle otherwise unhandled exceptions that occur in `asyncHandler`.  When such an exception `err` occurs, the handler will `reply(err)`.
-
-```js
-server.route({
-    method: 'get',
-    path: '/user/{id}',
-    handler: Toys.handler(async function(request, reply) {
-
-        const user = await getUser(request.params.id);
-
-        if (!user) {
-            throw Boom.notFound('User not found'); // This will work!
-        }
-
-        return reply(user);
-    })
-});
-```
-
-### `Toys.handler(server, notation)`
-> As instance, `toys.handler(notation)`
-
-Returns a route handler function given a hapi `server` and a short-hand string `notation` referencing a server method on that server.
-
-Note that the server method is resolved at the time of the request, so monkey-patching server methods will work correctly; hapi's short-hand for server method handlers does not support monkey-patching server methods, which is often useful during testing.
-
-#### `notation` format
-The `notation` parameter should be in the format `name(args)` or `name` where,
- - `name` - the method name, e.g. `users.fetch`.
- - `args` - the method arguments where each argument is a property of the request object.  If the server method takes a callback then the last argument should be called `cb`, `callback`, or `next`.  If `(args)` are omitted entirely then the args will implicitly be `(request, reply)`.
-
-Here are some valid examples,
- - `'someMethodHandler'`
- - `'latestNews()'`
- - `'users.fetch(params.id, cb)'`
- - `'add(query.a, query.b)'`
-
-```js
-server.method({
-    name: 'users.fetch',
-    method: (id, callback) => {
-        return getUserById(id, callback);
-    }
-});
-
-server.route({
-    method: 'get',
-    path: '/user/{userId}',
-    handler: Toys.handler(server, 'users.fetch(params.userId, cb)')
-});
-```
-
-### `Toys.pre(server, notation, [options])`
-> As instance, `toys.pre(notation, [options])`
-
-Returns a [route prerequisite object](https://github.com/hapijs/hapi/blob/v16/API.md#route-prerequisites) given a hapi `server`, a short-hand string `notation` (described [above](#notation-format)) referencing a server method on that server, and optional `options` to set the prerequisite's `assign` or `failAction`.  By default `assign` is set to the server method's name.
-
-```js
-server.method({
-    name: 'add',
-    method: (a, b) => {
-        return parseInt(a) + parseInt(b);
-    },
-    options: { callback: false }
-});
-
-server.route({
-    method: 'get',
-    path: '/{a}/{b}',
-    config: {
-        pre: [
-            Toys.pre(server, 'add(params.a, params.b)')
-        ],
-        handler: function (request, reply) {
-
-            reply(`Magic number is ${request.pre.add}`);
-        }
-    }
-});
-```
-
 ### `Toys.ext(method, [options])`
 > As instance, `toys.ext(method, [options])`
 
-Returns a hapi [extension config](https://github.com/hapijs/hapi/blob/v16/API.md#serverextevents) `{ method, options }` without the `type` field. The config only has `options` set when provided as an argument.  This intended to be used with the route `ext` config.
+Returns a hapi [extension config](https://github.com/hapijs/hapi/blob/master/API.md#server.ext()) `{ method, options }` without the `type` field. The config only has `options` set when provided as an argument.  This intended to be used with the route `ext` config.
 
 ```js
 server.route({
     method: 'get',
     path: '/',
-    config: {
-        handler: function (request, reply) {
+    options: {
+        handler: (request) => {
 
-            return reply({ ok: true });
+            return { ok: true };
         },
         ext: {
-            onPostAuth: Toys.ext((request, reply) => {
+            onPostAuth: Toys.ext((request, h) => {
 
                 if (!request.headers['special-header']) {
-                    return reply(Boom.unauthorized());
+                    throw Boom.unauthorized();
                 }
 
-                return reply.continue();
+                return h.continue;
             })
         }
     }
@@ -154,19 +66,19 @@ server.route({
 ### `Toys.EXTENSION(method, [options])`
 > As instance, `toys.EXTENSION(method, [options])`
 
-Returns a hapi [extension config](https://github.com/hapijs/hapi/blob/v16/API.md#serverextevents) `{ type, method, options}` with the `type` field set to `EXTENSION`, where `EXTENSION` is any of `onRequest`, `onPreAuth`, `onPostAuth`, `onPreHandler`, `onPostHandler`, `onPreResponse`, `onPreStart`, `onPostStart`, `onPreStop`, or `onPostStop`. The config only has `options` set when provided as an argument.  This is intended to be used with [`server.ext()`](https://github.com/hapijs/hapi/blob/v16/API.md#serverextevents).
+Returns a hapi [extension config](https://github.com/hapijs/hapi/blob/master/API.md#server.ext()) `{ type, method, options}` with the `type` field set to `EXTENSION`, where `EXTENSION` is any of `onRequest`, `onPreAuth`, `onPostAuth`, `onCredentials`, `onPreHandler`, `onPostHandler`, `onPreResponse`, `onPreStart`, `onPostStart`, `onPreStop`, or `onPostStop`. The config only has `options` set when provided as an argument.  This is intended to be used with [`server.ext()`](https://github.com/hapijs/hapi/blob/master/API.md#server.ext()).
 
 ```js
 server.ext([
-    Toys.onPreAuth((request, reply) => {
+    Toys.onPreAuth((request, h) => {
 
         if (!request.query.specialParam) {
-            return reply(Boom.unauthorized());
+            throw Boom.unauthorized();
         }
 
-        return reply.continue();
+        return h.continue;
     }),
-    Toys.onPreResponse((request, reply) => {
+    Toys.onPreResponse((request, h) => {
 
         if (!request.response.isBoom &&
             request.query.specialParam === 'secret') {
@@ -174,49 +86,11 @@ server.ext([
             request.log(['my-plugin'], 'Someone knew a secret');
         }
 
-        return reply.continue();        
+        return h.continue;        
     }, {
         sandbox: true
     })
 ]);
-```
-
-### `Toys.promisify([CustomPromise], fn)`
-> As instance, `toys.promisify(fn)`
-
-Promisifies callback-style function `fn`.  When `CustomPromise` is provided, it is used as a `Promise` constructor rather than native promises.  If `fn`'s callback receives more arguments than `function(err, value)` then those arguments are ignored.  This is intended to help promisify cacheable server methods, which require a callback using multiple value arguments.
-
-```js
-server.method({
-    name: 'getTodaysWeather',
-    method: (cb) => {
-        obtainTheWeather((err, weather) => {
-
-            if (err) {
-                return cb(err);
-            }
-
-            return cb(null, weather.today);
-        });
-    },
-    options: {
-        cache: {                        // Requires use of callback
-            expiresIn: 1000 * 60 * 15,  // 15min
-            generateTimeout: 200
-        }
-    }
-});
-
-server.methods.getTodaysWeather = Toys.promisify(server.methods.getTodaysWeather);
-
-server.methods.getTodaysWeather()
-.then((todaysWeather) => {
-    // This result should be cached for 15min
-    server.log(['weather'], todaysWeather);
-})
-.catch((err) => {
-    server.log(['weather', 'error'], err);
-});
 ```
 
 ### `Toys.reacher(chain, [options])`
@@ -230,17 +104,17 @@ const getAuthedGroupId = Toys.reacher('auth.credentials.user.group.id');
 server.route({
     method: 'get',
     path: '/user/group',
-    config: {
+    options: {
         auth: 'my-strategy',
-        handler: function (request, reply) {
+        handler: (request) => {
 
             const group = getAuthedGroupId(request);
 
             if (group !== 'BRS') {
-                return reply(Boom.unauthorized());
+                throw Boom.unauthorized();
             }
 
-            return reply({ group });
+            return { group };
         }
     }
 });
@@ -263,13 +137,13 @@ const userAddress = Toys.transformer({
 server.route({
     method: 'get',
     path: '/user/address',
-    config: {
+    options: {
         auth: 'my-strategy',
-        handler: function (request, reply) {
+        handler: (request) => {
 
             const address = userAddress(request.auth.credentials);
 
-            return reply({ address });
+            return { address };
         }
     }
 });
@@ -278,38 +152,28 @@ server.route({
 ### `Toys.auth.strategy(server, name, authenticate)`
 > As instance, `toys.auth.strategy(name, authenticate)`
 
-Adds an auth scheme and strategy with name `name` to `server`.  Its implementation is given by `authenticate` as described in [`server.auth.scheme()`](https://github.com/hapijs/hapi/blob/v16/API.md#serverauthschemename-scheme).  This is intended to make it simple to create a barebones auth strategy without having to create a reusable auth scheme; it is often useful for testing and simple auth implementations.
+Adds an auth scheme and strategy with name `name` to `server`.  Its implementation is given by `authenticate` as described in [`server.auth.scheme()`](https://github.com/hapijs/hapi/blob/master/API.md#server.auth.scheme()).  This is intended to make it simple to create a barebones auth strategy without having to create a reusable auth scheme; it is often useful for testing and simple auth implementations.
 
 ```js
-Toys.auth.strategy(server, 'simple-bearer', (request, reply) => {
+Toys.auth.strategy(server, 'simple-bearer', async (request, h) => {
 
     const token = (request.headers.authorization || '').replace('Bearer ', '');
 
     if (!token) {
-        return reply(Boom.unauthorized(null, 'Bearer'));
+        throw Boom.unauthorized(null, 'Bearer');
     }
 
-    lookupSession(token, (err, session) => {
+    const credentials = await lookupSession(token);
 
-        if (err) {
-            return reply(err);
-        }
-
-        return reply.continue({ credentials: session })
-    });
+    return h.authenticated({ credentials });
 });
 
 server.route({
     method: 'get',
     path: '/user',
-    config: {
+    options: {
         auth: 'simple-bearer',
-        handler: function (request, reply) {
-
-            const user = request.auth.credentials.user;
-
-            return reply({ user });
-        }
+        handler: (request) => request.auth.credentials.user
     }
 });
 ```

--- a/API.md
+++ b/API.md
@@ -229,6 +229,7 @@ const Fs = require('fs');
 const Crypto = require('crypto');
 
 // Hash a file and cache the result by filename
+
 server.method({
     name: 'hash',
     method: async (filename) => {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Lead Maintainer - [Devin Ivy](https://github.com/devinivy)
 
 Toys is a collection of utilities made to reduce common boilerplate in **hapi v17+** projects, aid usage of events and streams in `async` functions (e.g. handlers and server methods), and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
 
-Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyserver-name-authenticate), [`Toys.reacher()`](API.md#toysreacherchain-options), and [`Toys.withRouteDefaults()`](API.md#toyswithroutedefaultsdefaults-isnulloverride).  The [API Reference](API.md) is also filled with examples.
+Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyserver-name-authenticate), [`Toys.reacher()`](API.md#toysreacherchain-options), and [`Toys.withRouteDefaults()`](API.md#toyswithroutedefaultsdefaults).  The [API Reference](API.md) is also filled with examples.
 
 ```js
 const Hapi = require('hapi');

--- a/README.md
+++ b/README.md
@@ -9,69 +9,66 @@ Lead Maintainer - [Devin Ivy](https://github.com/devinivy)
 ## Usage
 > See also the [API Reference](API.md)
 
-Toys is a collection of utilities made to reduce common boilerplate in hapi projects, alleviate a few of hapi's quirks, and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
+Toys is a collection of utilities made to reduce common boilerplate in **hapi v17+** projects, aid usage of events and streams in `async` functions (e.g. handlers and server methods), and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
 
-Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyserver-name-authenticate), [`Toys.reacher()`](API.md#toysreacherchain-options), and [`Toys.withDefaults()`](API.md#toyswithdefaultsdefaults-isnulloverride).
+Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyserver-name-authenticate), [`Toys.reacher()`](API.md#toysreacherchain-options), and [`Toys.withRouteDefaults()`](API.md#toyswithroutedefaultsdefaults-isnulloverride).  The [API Reference](API.md) is also filled with examples.
 
 ```js
 const Hapi = require('hapi');
 const Boom = require('boom');
 const Toys = require('toys');
 
-const server = new Hapi.Server();
-server.connection();
+(async () => {
 
-// Make a one-off auth strategy for testing
-Toys.auth.strategy(server, 'name-from-param', (request, reply) => {
+    const server = Hapi.server();
 
-    // Yes, perhaps not the most secure
-    const username = request.params.username;
+    // Make a one-off auth strategy for testing
+    Toys.auth.strategy(server, 'name-from-param', (request, h) => {
 
-    if (!username) {
-        return reply(Boom.unauthorized(null, 'Custom'));
-    }
+        // Yes, perhaps not the most secure
+        const { username } = request.params;
 
-    return reply.continue({ credentials: { user: { name: username } } });
-});
+        if (!username) {
+            throw Boom.unauthorized(null, 'Custom');
+        }
 
-// Make function to efficiently index into a request to grab an authed user's name
-const grabAuthedUsername = Toys.reacher('auth.credentials.user.name');
+        return h.authenticated({ credentials: { user: { name: username } } });
+    });
 
-// Default all route methods to "get", unless otherwise specified
-const defaultToGet = Toys.withDefaults({ method: 'get' });
+    // Make function to efficiently index into a request to grab an authed user's name
+    const grabAuthedUsername = Toys.reacher('auth.credentials.user.name');
 
-server.route(
-    defaultToGet([
-        {
-            method: 'post',
-            path: '/',
-            handler: function (request, reply) {
+    // Default all route methods to "get", unless otherwise specified
+    const defaultToGet = Toys.withRouteDefaults({ method: 'get' });
 
-                return reply({ posted: true });
-            }
-        },
-        {   // Look ma, my method is defaulting to "get"!
-            path: '/as/{username}',
-            config: {
-                auth: 'name-from-param', // Here's our simple auth strategy
-                handler: function (request, reply) {
+    server.route(
+        defaultToGet([
+            {
+                method: 'post',
+                path: '/',
+                handler: (request) => {
 
-                    // grabAuthedUsername() is designed to be quick
-                    const username = grabAuthedUsername(request);
+                    return { posted: true };
+                }
+            },
+            {   // Look ma, my method is defaulting to "get"!
+                path: '/as/{username}',
+                options: {
+                    auth: 'name-from-param', // Here's our simple auth strategy
+                    handler: (request) => {
 
-                    return reply({ username });
+                        // grabAuthedUsername() is designed to be quick
+                        const username = grabAuthedUsername(request);
+
+                        return { username };
+                    }
                 }
             }
-        }
-    ])
-);
+        ])
+    );
 
-server.start((err) => {
-
-    if (err) {
-        throw err;
-    }
+    await server.start();
 
     console.log(`Now, go forth and ${server.info.uri}/as/your-name`);
-});
+})();
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,9 @@ const internals = {};
 
 module.exports = exports = class {
 
-    constructor(server, CustomPromise) {
+    constructor(server) {
 
         this.server = server;
-        this.CustomPromise = CustomPromise;
     }
 
     static withDefaults(defaults, isNullOverride) {
@@ -29,51 +28,21 @@ module.exports = exports = class {
         return this.constructor.withDefaults(defaults, isNullOverride);
     }
 
-    static handler(handlerOrServer, notation) {
+    static withRouteDefaults(defaults) {
 
-        if (typeof handlerOrServer === 'function') {
-            const asyncHandler = handlerOrServer;
+        return (options) => {
 
-            return function (request, reply) {
+            if (Array.isArray(options)) {
+                return options.map((opt) => internals.applyRouteDefaults(defaults, opt));
+            }
 
-                return asyncHandler.call(this, request, reply).catch(reply);
-            };
-        }
-
-        const server = handlerOrServer;
-        return internals.fromString('handler', server, notation).method;
+            return internals.applyRouteDefaults(defaults, options);
+        };
     }
 
-    handler(handlerOrNotation) {
+    withRouteDefaults(defaults) {
 
-        if (typeof handlerOrNotation === 'function') {
-            const handler = handlerOrNotation;
-            return this.constructor.handler(handler);
-        }
-
-        const notation = handlerOrNotation;
-        return this.constructor.handler(this.server, notation);
-    }
-
-    static pre(server, notation, options) {
-
-        options = options || {};
-
-        const pre = (typeof options === 'string') ? { assign: options } : Hoek.shallow(options);
-
-        Hoek.assert(!pre.method, 'pre() will create a prerequisite method for you, so it cannot be specified in options.');
-
-        const parsed = internals.fromString('pre', server, notation);
-
-        pre.method = parsed.method;
-        pre.assign = pre.assign || parsed.name;
-
-        return pre;
-    }
-
-    pre(notation, options) {
-
-        return this.constructor.pre(this.server, notation, options);
+        return this.constructor.withDefaults(defaults);
     }
 
     static ext(method, options) {
@@ -104,6 +73,16 @@ module.exports = exports = class {
     onPreAuth(method, options) {
 
         return this.constructor.onPreAuth(method, options);
+    }
+
+    static onCredentials(method, options) {
+
+        return internals.ext('onCredentials', method, options);
+    }
+
+    onCredentials(method, options) {
+
+        return this.constructor.onCredentials(method, options);
     }
 
     static onPostAuth(method, options) {
@@ -302,45 +281,6 @@ module.exports = exports = class {
         return this.constructor.transformer(transform, options);
     }
 
-    static promisify(CustomPromise, method) {
-
-        if (!method) {
-            method = CustomPromise;
-            CustomPromise = null;
-        }
-
-        CustomPromise = CustomPromise || Promise;
-
-        return function () {
-
-            const len = arguments.length;
-            const args = new Array(len + 1);
-
-            for (let i = 0; i < len; ++i) {
-                args[i] = arguments[i];
-            }
-
-            return new CustomPromise((resolve, reject) => {
-
-                args[len] = (err, value) => {
-
-                    if (err) {
-                        return reject(err);
-                    }
-
-                    return resolve(value);
-                };
-
-                return method.apply(null, args);
-            });
-        };
-    }
-
-    promisify(method) {
-
-        return this.constructor.promisify(this.CustomPromise, method);
-    }
-
     static get auth() {
 
         return {
@@ -354,6 +294,153 @@ module.exports = exports = class {
             strategy: this.constructor.auth.strategy.bind(this, this.server)
         };
     }
+
+    static get noop() {
+
+        return internals.noop;
+    }
+
+    get noop() {
+
+        return this.constructor.noop;
+    }
+
+    static async event(emitter, name) {
+
+        return await internals.event(emitter, name);
+    }
+
+    async event(emitter, name) {
+
+        return await this.constructor.event(emitter, name);
+    }
+
+    static async stream(stream) {
+
+        Hoek.assert(stream.readable || stream.writable, 'Stream must be readable or writable');
+
+        if (stream.readable && !stream.writable) {
+            await internals.event(stream, 'end');
+            return;
+        }
+        else if (!stream.readable && stream.writable) {
+            await internals.event(stream, 'finish');
+            return;
+        }
+
+        await Promise.all([
+            internals.event(stream, 'end'),
+            internals.event(stream, 'finish')
+        ]);
+    }
+
+    async stream(stream) {
+
+        return await this.constructor.stream(stream);
+    }
+
+    static forEachAncestorRealm(realm, fn) {
+
+        do {
+            fn(realm);
+            realm = realm.parent;
+        }
+        while (realm);
+    }
+
+    forEachAncestorRealm(fn) {
+
+        return this.constructor.forEachAncestorRealm(this.server.realm, fn);
+    }
+
+    static rootRealm(realm) {
+
+        while (realm.parent) {
+            realm = realm.parent;
+        }
+
+        return realm;
+    }
+
+    rootRealm() {
+
+        return this.constructor.rootRealm(this.server.realm);
+    }
+
+    static state(realm, name) {
+
+        return internals.state(realm, name);
+    }
+
+    state(name) {
+
+        return this.constructor.state(this.server.realm, name);
+    }
+
+    static rootState(realm, name) {
+
+        while (realm.parent) {
+            realm = realm.parent;
+        }
+
+        return internals.state(realm, name);
+    }
+
+    rootState(name) {
+
+        return this.constructor.rootState(this.server.realm, name);
+    }
+};
+
+internals.applyRouteDefaults = (defaults, options) => {
+
+    return Hoek.applyToDefaultsWithShallow(defaults, options, [
+        'options.bind',
+        'config.bind',
+        'options.validate.headers',
+        'config.validate.headers',
+        'options.validate.payload',
+        'config.validate.payload',
+        'options.validate.params',
+        'config.validate.params',
+        'options.validate.query',
+        'config.validate.query'
+    ]);
+};
+
+internals.state = (realm, name) => {
+
+    const state = realm.plugins[name] = realm.plugins[name] || {};
+    return state;
+};
+
+internals.event = (emitter, name) => {
+
+    return new Promise((resolve, reject) => {
+
+        const onSuccess = (value) => {
+
+            emitter.removeListener('error', onError);
+
+            return resolve(value);
+        };
+
+        const onError = (err) => {
+
+            emitter.removeListener(name, onSuccess);
+
+            return reject(err);
+        };
+
+        emitter.once(name, onSuccess);
+        emitter.once('error', onError);
+    });
+};
+
+internals.noop = {
+    name: 'noop',
+    multiple: true,
+    register: Hoek.ignore
 };
 
 internals.strategy = (server, name, authenticate) => {
@@ -376,69 +463,3 @@ internals.ext = (type, method, options) => {
 
     return extConfig;
 };
-
-internals.fromString = function (type, server, notation) {
-
-    //                                  1:name            2:(        3:arguments
-    const methodParts = notation.match(/^([\w\.]+)(?:\s*)(?:(\()(?:\s*)(\w+(?:\.\w+)*(?:\s*\,\s*\w+(?:\.\w+)*)*)?(?:\s*)\))?$/);
-    Hoek.assert(methodParts, `Invalid server method string notation: ${notation}`);
-
-    const name = methodParts[1];
-    Hoek.assert(name.match(internals.methodNameRx), `Invalid server method name: ${name}`);
-
-    const getMethod = exports.reacher(name);
-    Hoek.assert(getMethod(server.methods), `Unknown server method in string notation: ${notation}`);
-
-    const argsNotation = !!methodParts[2];
-    const methodArgs = (argsNotation ? (methodParts[3] || '').split(/\s*\,\s*/) : []);
-
-    const result = { name };
-
-    if (!argsNotation) {
-        result.method = (request, reply) => getMethod(server.methods)(request, reply);
-        return result;
-    }
-
-    let useCallback = false;
-    const argReachers = [];
-
-    for (let i = 0; i < methodArgs.length; ++i) {
-        const arg = methodArgs[i];
-
-        if (i === methodArgs.length - 1 && (arg === 'cb' || arg === 'callback' || arg === 'next')) {
-            useCallback = true;
-        }
-        else if (arg) {
-            argReachers.push(exports.reacher(arg));
-        }
-    }
-
-    result.method = (request, reply) => {
-
-        const args = [];
-        for (let i = 0; i < argReachers.length; ++i) {
-            args.push(argReachers[i](request));
-        }
-
-        if (!useCallback) {
-            const response = getMethod(server.methods).apply(null, args);
-            return reply(response);
-        }
-
-        const finalize = (err, value, cached, report) => {
-
-            if (report) {
-                request.log([type, 'method', name], report);
-            }
-
-            return reply(err, value);
-        };
-
-        args.push(finalize);
-        getMethod(server.methods).apply(null, args);
-    };
-
-    return result;
-};
-
-internals.methodNameRx = /^[_$a-zA-Z][$\w]*(?:\.[_$a-zA-Z][$\w]*)*$/;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,28 +4,11 @@ const Hoek = require('hoek');
 
 const internals = {};
 
-module.exports = exports = class {
+module.exports = class Toys {
 
     constructor(server) {
 
         this.server = server;
-    }
-
-    static withDefaults(defaults, isNullOverride) {
-
-        return (options) => {
-
-            if (Array.isArray(options)) {
-                return options.map((opt) => Hoek.applyToDefaults(defaults, opt, isNullOverride));
-            }
-
-            return Hoek.applyToDefaults(defaults, options, isNullOverride);
-        };
-    }
-
-    withDefaults(defaults, isNullOverride) {
-
-        return this.constructor.withDefaults(defaults, isNullOverride);
     }
 
     static withRouteDefaults(defaults) {
@@ -42,7 +25,7 @@ module.exports = exports = class {
 
     withRouteDefaults(defaults) {
 
-        return this.constructor.withDefaults(defaults);
+        return this.constructor.withRouteDefaults(defaults);
     }
 
     static ext(method, options) {
@@ -390,7 +373,42 @@ module.exports = exports = class {
 
         return this.constructor.rootState(this.server.realm, name);
     }
+
+    static realm(obj) {
+
+        if (internals.isRealm(obj && obj.realm)) {
+            // Server, route, response toolkit
+            return obj.realm;
+        }
+        else if (internals.isRealm(obj && obj.route && obj.route.realm)) {
+            // Request
+            return obj.route.realm;
+        }
+
+        Hoek.assert(internals.isRealm(obj), 'Must pass a request, server, route, response toolkit, or realm');
+
+        // Realm
+        return obj;
+    }
+
+    realm(obj = this.server) {
+
+        return this.constructor.realm(obj);
+    }
+
+    static options(obj) {
+
+        return this.realm(obj).pluginOptions;
+    }
+
+    options(obj = this.server) {
+
+        return this.constructor.options(obj);
+    }
 };
+
+// Looks like a realm
+internals.isRealm = (obj) => obj && obj.hasOwnProperty('pluginOptions') && obj.hasOwnProperty('modifiers');
 
 internals.applyRouteDefaults = (defaults, options) => {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,11 @@ module.exports = class Toys {
 
     static get noop() {
 
-        return internals.noop;
+        return {
+            name: 'toys-noop',
+            multiple: true,
+            register: Hoek.ignore
+        };
     }
 
     get noop() {
@@ -385,7 +389,7 @@ module.exports = class Toys {
             return obj.route.realm;
         }
 
-        Hoek.assert(internals.isRealm(obj), 'Must pass a request, server, route, response toolkit, or realm');
+        Hoek.assert(internals.isRealm(obj), 'Must pass a server, request, route, response toolkit, or realm');
 
         // Realm
         return obj;
@@ -453,12 +457,6 @@ internals.event = (emitter, name) => {
         emitter.once(name, onSuccess);
         emitter.once('error', onError);
     });
-};
-
-internals.noop = {
-    name: 'noop',
-    multiple: true,
-    register: Hoek.ignore
 };
 
 internals.strategy = (server, name, authenticate) => {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,12 @@
   },
   "homepage": "https://github.com/devinivy/toys#readme",
   "dependencies": {
-    "hoek": "4.x.x"
+    "hoek": "5.x.x"
   },
   "devDependencies": {
-    "boom": "5.x.x",
-    "code": "4.x.x",
+    "code": "5.x.x",
     "coveralls": "3.x.x",
-    "hapi": "16.x.x",
-    "lab": "14.x.x",
-    "pinkie": "2.x.x"
+    "hapi": "17.x.x",
+    "lab": "15.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,6 @@
 const Lab = require('lab');
 const Code = require('code');
 const Hapi = require('hapi');
-const Boom = require('boom');
-const Pinkie = require('pinkie');
 const Toys = require('..');
 
 // Test shortcuts
@@ -31,44 +29,39 @@ describe('Toys', () => {
             g: 'test'
         };
 
-        it('throws when target is null.', (done) => {
+        it('throws when target is null.', () => {
 
             expect(() => {
 
                 Toys.withDefaults(null)({});
             }).to.throw('Invalid defaults value: must be an object');
-            done();
         });
 
-        it('returns null if options is false.', (done) => {
+        it('returns null if options is false.', () => {
 
             const result = Toys.withDefaults(defaults)(false);
             expect(result).to.equal(null);
-            done();
         });
 
-        it('returns null if options is null.', (done) => {
+        it('returns null if options is null.', () => {
 
             const result = Toys.withDefaults(defaults)(null);
             expect(result).to.equal(null);
-            done();
         });
 
-        it('returns null if options is undefined.', (done) => {
+        it('returns null if options is undefined.', () => {
 
             const result = Toys.withDefaults(defaults)(undefined);
             expect(result).to.equal(null);
-            done();
         });
 
-        it('returns a copy of defaults if options is true.', (done) => {
+        it('returns a copy of defaults if options is true.', () => {
 
             const result = Toys.withDefaults(defaults)(true);
             expect(result).to.equal(defaults);
-            done();
         });
 
-        it('applies object to defaults.', (done) => {
+        it('applies object to defaults.', () => {
 
             const obj = {
                 a: null,
@@ -87,10 +80,9 @@ describe('Toys', () => {
             expect(result.b).to.equal(2);
             expect(result.f).to.equal(0);
             expect(result.g).to.equal({ h: 5 });
-            done();
         });
 
-        it('maps array objects over defaults.', (done) => {
+        it('maps array objects over defaults.', () => {
 
             const obj = {
                 a: null,
@@ -115,11 +107,9 @@ describe('Toys', () => {
                 expect(result.f).to.equal(0);
                 expect(result.g).to.equal({ h: 5 });
             });
-
-            done();
         });
 
-        it('applies object to defaults multiple times.', (done) => {
+        it('applies object to defaults multiple times.', () => {
 
             const obj = {
                 a: null,
@@ -137,10 +127,9 @@ describe('Toys', () => {
             const twice = withDefaults(obj);
 
             expect(once).to.equal(twice);
-            done();
         });
 
-        it('applies object to defaults with null.', (done) => {
+        it('applies object to defaults with null.', () => {
 
             const obj = {
                 a: null,
@@ -159,10 +148,9 @@ describe('Toys', () => {
             expect(result.b).to.equal(2);
             expect(result.f).to.equal(0);
             expect(result.g).to.equal({ h: 5 });
-            done();
         });
 
-        it('works as an instance method.', (done) => {
+        it('works as an instance method.', () => {
 
             const obj = {
                 a: null,
@@ -183,425 +171,6 @@ describe('Toys', () => {
             expect(result.b).to.equal(2);
             expect(result.f).to.equal(0);
             expect(result.g).to.equal({ h: 5 });
-            done();
-        });
-    });
-
-    describe('handler()', () => {
-
-        it('catches failure in async handler, maintaining context.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.bind({ ctx: 'aware' });
-
-            server.route({
-                method: 'get',
-                path: '/',
-                handler: Toys.handler(function (request, reply) {
-
-                    return Promise.reject(Boom.badData(`Context ${this.ctx}`)); // async fns are simply promise-returning
-                })
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.statusCode).to.equal(422);
-                expect(res.result.message).to.equal('Context aware');
-                done();
-            });
-        });
-
-        it('accepts string notation, as plain hander.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('handler.get', (request, reply) => {
-
-                return reply(null, request.params.x + request.params.y).code(299);
-            });
-
-            server.route({
-                method: 'get',
-                path: '/{x}/{y}',
-                handler: Toys.handler(server, 'handler.get')
-            });
-
-            server.inject('/a/b', (res) => {
-
-                expect(res.statusCode).to.equal(299);
-                expect(res.result).to.equal('ab');
-                done();
-            });
-        });
-
-        it('accepts string notation, with arguments.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('perform.addition', (a, b) =>  Number(a) + Number(b), {
-                callback: false
-            });
-
-            server.route({
-                method: 'get',
-                path: '/{x}/{y}',
-                handler: Toys.handler(server, 'perform.addition(params.x, params.y)')
-            });
-
-            server.inject('/2/7', (res) => {
-
-                expect(res.result).to.equal(9);
-                done();
-            });
-        });
-
-        it('accepts string notation, with zero args.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('the.answer', () => 42, {
-                callback: false
-            });
-
-            server.route({
-                method: 'get',
-                path: '/',
-                handler: Toys.handler(server, 'the.answer()')
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.result).to.equal(42);
-                done();
-            });
-        });
-
-        it('accepts string notation, with a callback.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('calling.back', (a, b, cb) => {
-
-                return cb(null, Number(a) + Number(b));
-            });
-
-            server.route({
-                method: 'get',
-                path: '/cb/{a}/{b}',
-                handler: Toys.handler(server, 'calling.back(params.a, params.b, cb)')
-            });
-
-            server.route({
-                method: 'get',
-                path: '/callback/{a}/{b}',
-                handler: Toys.handler(server, 'calling.back(params.a, params.b, callback)')
-            });
-
-            server.route({
-                method: 'get',
-                path: '/next/{a}/{b}',
-                handler: Toys.handler(server, 'calling.back(params.a, params.b, next)')
-            });
-
-            server.inject('/cb/1/2', (res1) => {
-
-                expect(res1.result).to.equal(3);
-
-                server.inject('/callback/2/4', (res2) => {
-
-                    expect(res2.result).to.equal(6);
-
-                    server.inject('/next/4/8', (res3) => {
-
-                        expect(res3.result).to.equal(12);
-                        done();
-                    });
-                });
-            });
-        });
-
-        it('logs cached server method report.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection({ routes: { log: true } });
-
-            server.method('the.answer', (cb) => cb(null, 42), {
-                cache: {
-                    expiresIn: 1000,
-                    generateTimeout: 10
-                }
-            });
-
-            server.route({
-                method: 'get',
-                path: '/',
-                handler: Toys.handler(server, 'the.answer(cb)')
-            });
-
-            server.initialize((err) => {
-
-                expect(err).to.not.exist();
-
-                server.inject('/', (res) => {
-
-                    expect(res.result).to.equal(42);
-
-                    const log = res.request.getLog('method')[0];
-
-                    expect(log).to.exist();
-                    expect(log.tags).to.equal(['handler', 'method', 'the.answer']);
-                    expect(log.internal).to.equal(false);
-                    expect(log.data.msec).to.exist();
-                    done();
-                });
-            });
-        });
-
-        it('resolves server method lazily.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('perform.operation', (a, b, cb) => cb(null, Number(a) + Number(b)));
-
-            server.route({
-                method: 'get',
-                path: '/{x}/{y}',
-                handler: Toys.handler(server, 'perform.operation(params.x, params.y, cb)')
-            });
-
-            server.methods.perform.operation = (a, b, cb) => cb(null, Number(a) * Number(b));
-
-            server.inject('/2/7', (res) => {
-
-                expect(res.result).to.equal(14);
-                done();
-            });
-        });
-
-        it('works as an instance method with string notation.', (done) => {
-
-            const server = new Hapi.Server();
-            const toys = new Toys(server);
-            server.connection();
-
-            server.method('perform.addition', (a, b, cb) => cb(null, Number(a) + Number(b)));
-
-            server.route({
-                method: 'get',
-                path: '/{x}/{y}',
-                handler: toys.handler('perform.addition(params.x, params.y, cb)')
-            });
-
-            server.inject('/2/7', (res) => {
-
-                expect(res.result).to.equal(9);
-                done();
-            });
-        });
-
-        it('works as an instance method with async function.', (done) => {
-
-            const server = new Hapi.Server();
-            const toys = new Toys();
-            server.connection();
-
-            server.bind({ ctx: 'aware' });
-
-            server.route({
-                method: 'get',
-                path: '/',
-                handler: toys.handler(function (request, reply) {
-
-                    return Promise.reject(Boom.badData(`Context ${this.ctx}`)); // async fns are simply promise-returning
-                })
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.statusCode).to.equal(422);
-                expect(res.result.message).to.equal('Context aware');
-                done();
-            });
-        });
-    });
-
-    describe('pre()', () => {
-
-        it('creates a route prereq with `assign` defaulting to server method\'s name.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('the.answer', (cb) => cb(null, 42));
-
-            server.route({
-                method: 'get',
-                path: '/',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        Toys.pre(server, 'the.answer(cb)')
-                    ]
-                }
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.result).to.equal({ 'the.answer': 42 });
-                done();
-            });
-        });
-
-        it('creates a route prereq with `assign` specified.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('the.answer', (cb) => cb(null, 42));
-
-            server.route({
-                method: 'get',
-                path: '/',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        Toys.pre(server, 'the.answer(cb)', 'my.answer')
-                    ]
-                }
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.result).to.equal({ 'my.answer': 42 });
-                done();
-            });
-        });
-
-        it('creates a route prereq with options.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('the.answer', (cb) => cb(null, 42));
-
-            server.route({
-                method: 'get',
-                path: '/',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        Toys.pre(server, 'the.answer(cb)', { assign: 'my.answer' })
-                    ]
-                }
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.result).to.equal({ 'my.answer': 42 });
-                done();
-            });
-        });
-
-        it('resolves server method lazily.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection();
-
-            server.method('perform.operation', (a, b, cb) => cb(null, Number(a) + Number(b)));
-
-            server.route({
-                method: 'get',
-                path: '/{x}/{y}',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        Toys.pre(server, 'perform.operation(params.x, params.y, cb)')
-                    ]
-                }
-            });
-
-            server.methods.perform.operation = (a, b, cb) => cb(null, Number(a) * Number(b));
-
-            server.inject('/2/7', (res) => {
-
-                expect(res.result).to.equal({ 'perform.operation': 14 });
-                done();
-            });
-        });
-
-        it('creates a route prereq that logs cached server method report.', (done) => {
-
-            const server = new Hapi.Server();
-            server.connection({ routes: { log: true } });
-
-            server.method('the.answer', (cb) => cb(null, 42), {
-                cache: {
-                    expiresIn: 1000,
-                    generateTimeout: 10
-                }
-            });
-
-            server.route({
-                method: 'get',
-                path: '/',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        Toys.pre(server, 'the.answer(cb)')
-                    ]
-                }
-            });
-
-            server.initialize((err) => {
-
-                expect(err).to.not.exist();
-
-                server.inject('/', (res) => {
-
-                    expect(res.result).to.equal({ 'the.answer': 42 });
-
-                    const log = res.request.getLog('method')[0];
-
-                    expect(log).to.exist();
-                    expect(log.tags).to.equal(['pre', 'method', 'the.answer']);
-                    expect(log.internal).to.equal(false);
-                    expect(log.data.msec).to.exist();
-                    done();
-                });
-            });
-        });
-
-        it('works as an instance method.', (done) => {
-
-            const server = new Hapi.Server();
-            const toys = new Toys(server);
-            server.connection();
-
-            server.method('the.answer', (cb) => cb(null, 42));
-
-            server.route({
-                method: 'get',
-                path: '/',
-                config: {
-                    handler: (request, reply) => reply(request.pre),
-                    pre: [
-                        toys.pre('the.answer(cb)', { assign: 'my.answer' })
-                    ]
-                }
-            });
-
-            server.inject('/', (res) => {
-
-                expect(res.result).to.equal({ 'my.answer': 42 });
-                done();
-            });
         });
     });
 
@@ -627,134 +196,113 @@ describe('Toys', () => {
 
         obj.i.x = 5;
 
-        it('returns object itself.', (done) => {
+        it('returns object itself.', () => {
 
             expect(Toys.reacher(null)(obj)).to.shallow.equal(obj);
             expect(Toys.reacher(false)(obj)).to.shallow.equal(obj);
             expect(Toys.reacher()(obj)).to.shallow.equal(obj);
-            done();
         });
 
-        it('returns first value of array.', (done) => {
+        it('returns first value of array.', () => {
 
             expect(Toys.reacher('k.0')(obj)).to.equal(4);
-            done();
         });
 
-        it('returns last value of array using negative index.', (done) => {
+        it('returns last value of array using negative index.', () => {
 
             expect(Toys.reacher('k.-2')(obj)).to.equal(9);
-            done();
         });
 
-        it('returns a valid member.', (done) => {
+        it('returns a valid member.', () => {
 
             expect(Toys.reacher('a.b.c.d')(obj)).to.equal(1);
-            done();
         });
 
-        it('returns a valid member with separator override.', (done) => {
+        it('returns a valid member with separator override.', () => {
 
             expect(Toys.reacher('a/b/c/d', '/')(obj)).to.equal(1);
-            done();
         });
 
-        it('returns undefined on null object.', (done) => {
+        it('returns undefined on null object.', () => {
 
             expect(Toys.reacher('a.b.c.d')(null)).to.equal(undefined);
-            done();
         });
 
-        it('returns undefined on missing object member.', (done) => {
+        it('returns undefined on missing object member.', () => {
 
             expect(Toys.reacher('a.b.c.d.x')(obj)).to.equal(undefined);
-            done();
         });
 
-        it('returns undefined on missing function member.', (done) => {
+        it('returns undefined on missing function member.', () => {
 
             expect(Toys.reacher('i.y', { functions: true })(obj)).to.equal(undefined);
-            done();
         });
 
-        it('throws on missing member in strict mode.', (done) => {
+        it('throws on missing member in strict mode.', () => {
 
             expect(() => {
 
                 Toys.reacher('a.b.c.o.x', { strict: true })(obj);
             }).to.throw('Missing segment o in reach path a.b.c.o.x');
-
-            done();
         });
 
-        it('returns undefined on invalid member.', (done) => {
+        it('returns undefined on invalid member.', () => {
 
             expect(Toys.reacher('a.b.c.d-.x')(obj)).to.equal(undefined);
-            done();
         });
 
-        it('returns function member.', (done) => {
+        it('returns function member.', () => {
 
             expect(typeof Toys.reacher('i')(obj)).to.equal('function');
-            done();
         });
 
-        it('returns function property.', (done) => {
+        it('returns function property.', () => {
 
             expect(Toys.reacher('i.x')(obj)).to.equal(5);
-            done();
         });
 
-        it('returns null.', (done) => {
+        it('returns null.', () => {
 
             expect(Toys.reacher('j')(obj)).to.equal(null);
-            done();
         });
 
-        it('throws on function property when functions not allowed.', (done) => {
+        it('throws on function property when functions not allowed.', () => {
 
             expect(() => {
 
                 Toys.reacher('i.x', { functions: false })(obj);
             }).to.throw('Invalid segment x in reach path i.x');
-
-            done();
         });
 
-        it('will return a default value if property is not found.', (done) => {
+        it('will return a default value if property is not found.', () => {
 
             expect(Toys.reacher('a.b.q', { default: 'defaultValue' })(obj)).to.equal('defaultValue');
-            done();
         });
 
-        it('will return a default value if path is not found.', (done) => {
+        it('will return a default value if path is not found.', () => {
 
             expect(Toys.reacher('q', { default: 'defaultValue' })(obj)).to.equal('defaultValue');
-            done();
         });
 
-        it('allows a falsey value to be used as the default value.', (done) => {
+        it('allows a falsey value to be used as the default value.', () => {
 
             expect(Toys.reacher('q', { default: '' })(obj)).to.equal('');
-            done();
         });
 
-        it('is reusable.', (done) => {
+        it('is reusable.', () => {
 
             const reacher = Toys.reacher('a.b.c.d');
             const anotherObj = { a: { b: { c: { d: 'x' } } } };
 
             expect(reacher(obj)).to.equal(1);
             expect(reacher(anotherObj)).to.equal('x');
-            done();
         });
 
-        it('works as an instance method.', (done) => {
+        it('works as an instance method.', () => {
 
             const toys = new Toys();
 
             expect(toys.reacher('a/b/c/d', '/')(obj)).to.equal(1);
-            done();
         });
     });
 
@@ -797,7 +345,7 @@ describe('Toys', () => {
             state: 'NY'
         }];
 
-        it('transforms an object based on the input object.', (done) => {
+        it('transforms an object based on the input object.', () => {
 
             const transform = Toys.transformer({
                 'person.address.lineOne': 'address.one',
@@ -820,11 +368,9 @@ describe('Toys', () => {
                 },
                 title: 'Warehouse'
             });
-
-            done();
         });
 
-        it('transforms an array of objects based on the input object.', (done) => {
+        it('transforms an array of objects based on the input object.', () => {
 
             const transform = Toys.transformer({
                 'person.address.lineOne': 'address.one',
@@ -861,11 +407,8 @@ describe('Toys', () => {
                     title: 'Garage'
                 }
             ]);
-
-            done();
         });
-
-        it('uses the reach options passed into it', (done) => {
+        it('uses the reach options passed into it', () => {
 
             const schema = {
                 'person-address-lineOne': 'address-one',
@@ -893,11 +436,9 @@ describe('Toys', () => {
                 },
                 title: 'Warehouse'
             });
-
-            done();
         });
 
-        it('uses a default separator for keys if options does not specify on', (done) => {
+        it('uses a default separator for keys if options does not specify on', () => {
 
             const schema = {
                 'person.address.lineOne': 'address.one',
@@ -924,11 +465,9 @@ describe('Toys', () => {
                 },
                 title: 'Warehouse'
             });
-
-            done();
         });
 
-        it('works to create shallow objects.', (done) => {
+        it('works to create shallow objects.', () => {
 
             const transform = Toys.transformer({
                 lineOne: 'address.one',
@@ -945,11 +484,9 @@ describe('Toys', () => {
                 region: 'CA',
                 province: null
             });
-
-            done();
         });
 
-        it('only allows strings in the map.', (done) => {
+        it('only allows strings in the map.', () => {
 
             expect(() => {
 
@@ -957,37 +494,29 @@ describe('Toys', () => {
                     lineOne: {}
                 });
             }).to.throw('All mappings must be strings');
-
-            done();
         });
 
-        it('throws an error on invalid arguments.', (done) => {
+        it('throws an error on invalid arguments.', () => {
 
             expect(() => {
 
                 Toys.transformer({})(NaN);
             }).to.throw('Invalid source object: must be null, undefined, an object, or an array');
-
-            done();
         });
 
-        it('is safe to pass null.', (done) => {
+        it('is safe to pass null.', () => {
 
             const transform = Toys.transformer({});
             expect(transform(null)).to.equal({});
-
-            done();
         });
 
-        it('is safe to pass undefined.', (done) => {
+        it('is safe to pass undefined.', () => {
 
             const transform = Toys.transformer({});
             expect(transform(undefined)).to.equal({});
-
-            done();
         });
 
-        it('is reusable.', (done) => {
+        it('is reusable.', () => {
 
             const transform = Toys.transformer({
                 lineOne: 'address.one',
@@ -1012,11 +541,9 @@ describe('Toys', () => {
                 region: 'NY',
                 province: null
             });
-
-            done();
         });
 
-        it('works as an instance method.', (done) => {
+        it('works as an instance method.', () => {
 
             const toys = new Toys();
             const transform = toys.transformer({
@@ -1034,90 +561,18 @@ describe('Toys', () => {
                 region: 'CA',
                 province: null
             });
-
-            done();
-        });
-    });
-
-    describe('promisify()', () => {
-
-        const fn = (value, cb) => {
-
-            if (value instanceof Error) {
-                return cb(value);
-            }
-
-            return cb(null, value, 'plus', 'extras');
-        };
-
-        it('promisifies a function, ignoring additional callback arguments.', () => {
-
-            const pifiedFn = Toys.promisify(fn);
-
-            return pifiedFn('24carat').then((value) => {
-
-                expect(value).to.equal('24carat');
-
-                return pifiedFn(new Error('0carat'));
-            }).catch((err) => {
-
-                expect(err).to.be.instanceof(Error);
-                expect(err.message).to.equal('0carat');
-            });
-        });
-
-        it('promisifies a function with specified promise implementation.', () => {
-
-            const pifiedFn = Toys.promisify(Pinkie, fn);
-            const promise = pifiedFn('24carat');
-
-            expect(promise).to.be.instanceof(Pinkie);
-
-            return promise.then((value) => {
-
-                expect(value).to.equal('24carat');
-            });
-        });
-
-        it('works as an instance method without custom promise implementation.', () => {
-
-            const toys = new Toys();
-            const pifiedFn = toys.promisify(fn);
-            const promise = pifiedFn('24carat');
-
-            expect(promise).to.be.instanceof(Promise);
-
-            return promise.then((value) => {
-
-                expect(value).to.equal('24carat');
-            });
-        });
-
-        it('works as an instance method with custom promise implementation.', () => {
-
-            const toys = new Toys(null, Pinkie);
-            const pifiedFn = toys.promisify(fn);
-            const promise = pifiedFn('24carat');
-
-            expect(promise).to.be.instanceof(Pinkie);
-
-            return promise.then((value) => {
-
-                expect(value).to.equal('24carat');
-            });
         });
     });
 
     describe('auth.strategy()', () => {
 
-        it('creates a one-off auth strategy with duplicate scheme name.', (done) => {
+        it('creates a one-off auth strategy with duplicate scheme name.', async () => {
 
-            const server = new Hapi.Server();
-            server.connection();
+            const server = Hapi.server();
 
-            Toys.auth.strategy(server, 'test-auth', (request, reply) => {
+            Toys.auth.strategy(server, 'test-auth', (request, h) => {
 
-                return reply.continue({ credentials: { user: 'bill' } });
+                return h.authenticated({ credentials: { user: 'bill' } });
             });
 
             // Reuse the scheme implicitly created above
@@ -1129,7 +584,7 @@ describe('Toys', () => {
                     path: '/',
                     config: {
                         auth: 'test-auth',
-                        handler: (request, reply) => reply(request.auth.credentials)
+                        handler: (request) => request.auth.credentials
                     }
                 },
                 {
@@ -1137,32 +592,28 @@ describe('Toys', () => {
                     path: '/again',
                     config: {
                         auth: 'test-auth-again',
-                        handler: (request, reply) => reply(request.auth.credentials)
+                        handler: (request) => request.auth.credentials
                     }
                 }
             ]);
 
-            server.inject('/', (res1) => {
+            const res1 = await server.inject('/');
 
-                expect(res1.result).to.equal({ user: 'bill' });
+            expect(res1.result).to.equal({ user: 'bill' });
 
-                server.inject('/again', (res2) => {
+            const res2 = await server.inject('/again');
 
-                    expect(res2.result).to.equal({ user: 'bill' });
-                    done();
-                });
-            });
+            expect(res2.result).to.equal({ user: 'bill' });
         });
 
-        it('works as an instance method.', (done) => {
+        it('works as an instance method.', async () => {
 
-            const server = new Hapi.Server();
+            const server = Hapi.server();
             const toys = new Toys(server);
-            server.connection();
 
-            toys.auth.strategy('test-auth', (request, reply) => {
+            toys.auth.strategy('test-auth', (request, h) => {
 
-                return reply.continue({ credentials: { user: 'bill' } });
+                return h.authenticated({ credentials: { user: 'bill' } });
             });
 
             server.route([
@@ -1171,16 +622,14 @@ describe('Toys', () => {
                     path: '/',
                     config: {
                         auth: 'test-auth',
-                        handler: (request, reply) => reply(request.auth.credentials)
+                        handler: (request) => request.auth.credentials
                     }
                 }
             ]);
 
-            server.inject('/', (res) => {
+            const res = await server.inject('/');
 
-                expect(res.result).to.equal({ user: 'bill' });
-                done();
-            });
+            expect(res.result).to.equal({ user: 'bill' });
         });
     });
 
@@ -1195,6 +644,7 @@ describe('Toys', () => {
         'onRequest',
         'onPreAuth',
         'onPostAuth',
+        'onCredentials',
         'onPreHandler',
         'onPostHandler',
         'onPreResponse'
@@ -1204,7 +654,7 @@ describe('Toys', () => {
 
         describe(`${ext}()`, () => {
 
-            it('creates a valid hapi request extension without options.', (done) => {
+            it('creates a valid hapi request extension without options.', () => {
 
                 const fn = function () {};
                 const extension = Toys[ext](fn);
@@ -1214,11 +664,9 @@ describe('Toys', () => {
                 expect(Object.keys(extension)).to.only.contain(keys);
                 isExt || expect(extension.type).to.equal(ext);
                 expect(extension.method).to.shallow.equal(fn);
-
-                done();
             });
 
-            it('creates a valid hapi request extension with options.', (done) => {
+            it('creates a valid hapi request extension with options.', () => {
 
                 const fn = function () {};
                 const opts = { before: 'loveboat' };
@@ -1230,11 +678,9 @@ describe('Toys', () => {
                 isExt || expect(extension.type).to.equal(ext);
                 expect(extension.method).to.shallow.equal(fn);
                 expect(extension.options).to.shallow.equal(opts);
-
-                done();
             });
 
-            it('works as an instance method.', (done) => {
+            it('works as an instance method.', () => {
 
                 const fn = function () {};
                 const opts = { before: 'loveboat' };
@@ -1247,8 +693,6 @@ describe('Toys', () => {
                 isExt || expect(extension.type).to.equal(ext);
                 expect(extension.method).to.shallow.equal(fn);
                 expect(extension.options).to.shallow.equal(opts);
-
-                done();
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -763,11 +763,11 @@ describe('Toys', () => {
 
             await server.register(Toys.noop);
 
-            expect(server.registrations).to.only.contain('noop');
+            expect(server.registrations).to.only.contain('toys-noop');
 
             await server.register(Toys.noop);
 
-            expect(server.registrations).to.only.contain('noop');
+            expect(server.registrations).to.only.contain('toys-noop');
         });
 
         it('works as an instance property.', async () => {
@@ -779,11 +779,11 @@ describe('Toys', () => {
 
             await server.register(toys.noop);
 
-            expect(server.registrations).to.only.contain('noop');
+            expect(server.registrations).to.only.contain('toys-noop');
 
             await server.register(toys.noop);
 
-            expect(server.registrations).to.only.contain('noop');
+            expect(server.registrations).to.only.contain('toys-noop');
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1180,8 +1180,8 @@ describe('Toys', () => {
 
         it('throws when passed an unfamiliar object.', () => {
 
-            expect(() => Toys.options({})).to.throw('Must pass a request, server, route, response toolkit, or realm');
-            expect(() => Toys.options(null)).to.throw('Must pass a request, server, route, response toolkit, or realm');
+            expect(() => Toys.options({})).to.throw('Must pass a server, request, route, response toolkit, or realm');
+            expect(() => Toys.options(null)).to.throw('Must pass a server, request, route, response toolkit, or realm');
         });
 
         it('works as an instance method, defaulting to get this.server\'s plugin options.', async () => {
@@ -1320,8 +1320,8 @@ describe('Toys', () => {
 
         it('throws when passed an unfamiliar object.', () => {
 
-            expect(() => Toys.realm({})).to.throw('Must pass a request, server, route, response toolkit, or realm');
-            expect(() => Toys.realm(null)).to.throw('Must pass a request, server, route, response toolkit, or realm');
+            expect(() => Toys.realm({})).to.throw('Must pass a server, request, route, response toolkit, or realm');
+            expect(() => Toys.realm(null)).to.throw('Must pass a server, request, route, response toolkit, or realm');
         });
 
         it('works as an instance method, defaulting to get this.server\'s realm.', async () => {


### PR DESCRIPTION
New,
 - [x] `Toys.onCredentials()`
 - [x] `Toys.noop`
 - [x] `async Toys.event()`
 - [x] `async Toys.stream()`
 - [x] `Toys.options()`
 - [x] `Toys.realm()`
 - [x] `Toys.rootRealm()`
 - [x] `Toys.state()`
 - [x] `Toys.rootState()`
 - [x] `Toys.forEachAncestorRealm()`

Removed,
 - [x] `Toys.handler()`
 - [x] `Toys.pre()`
 - [x] `Toys.promisify()`

Changed,
 - [x] `Toys.withDefaults()` -> `Toys.withRouteDefaults()`

Updated for v17,
 - [x] `Toys.auth.strategy()`