### PR TITLE
Add missing route-specific properties to shallow properties list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -462,7 +462,9 @@ internals.applyRouteDefaults = (defaults, options) => {
         'options.validate.params',
         'config.validate.params',
         'options.validate.query',
-        'config.validate.query'
+        'config.validate.query',
+        'options.response.schema',
+        'config.response.schema'
     ]);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -143,7 +143,10 @@ describe('Toys', () => {
                         headers: { defaults: true },
                         params: { defaults: true }
                     },
-                    bind: { defaults: true }
+                    bind: { defaults: true },
+                    response: {
+                        schema : { defaults: true }
+                    }
                 },
                 options: {
                     anything: { x: 1 },
@@ -153,7 +156,10 @@ describe('Toys', () => {
                         headers: { defaults: true },
                         params: { defaults: true }
                     },
-                    bind: { defaults: true }
+                    bind: { defaults: true },
+                    response: {
+                        schema : { defaults: true }
+                    }
                 }
             };
 
@@ -166,7 +172,10 @@ describe('Toys', () => {
                         headers: {},
                         params: {}
                     },
-                    bind: {}
+                    bind: {},
+                    response: {
+                        schema: {}
+                    }
                 },
                 options: {
                     anything: { y: 2 },
@@ -176,7 +185,10 @@ describe('Toys', () => {
                         headers: {},
                         params: {}
                     },
-                    bind: {}
+                    bind: {},
+                    response: {
+                        schema: {}
+                    }
                 }
             };
 
@@ -191,7 +203,10 @@ describe('Toys', () => {
                         headers: {},
                         params: {}
                     },
-                    bind: {}
+                    bind: {},
+                    response: {
+                        schema: {}
+                    }
                 },
                 options: {
                     anything: { x:1, y: 2 },
@@ -201,7 +216,10 @@ describe('Toys', () => {
                         headers: {},
                         params: {}
                     },
-                    bind: {}
+                    bind: {},
+                    response: {
+                        schema: {}
+                    }
                 }
             });
         });


### PR DESCRIPTION
It should do the trick I believe

related to #9 