### PR TITLE
Implement header(), getHeaders(), code(), and getCode()

### DIFF
--- a/API.md
+++ b/API.md
@@ -342,6 +342,34 @@ module.exports = {
 };
 ```
 
+### `Toys.header(response, name, value, [options])`
+> As instance, `toys.header(response, name, value, [options])`
+
+Designed to behave identically to hapi's [`response.header(name, value, [options])`](https://hapi.dev/api/#response.header()), but provide a unified interface for setting HTTP headers between both hapi [response objects](https://hapi.dev/api/#response-object) and [boom](https://hapi.dev/family/boom) errors.  This is useful in request extensions, when you don't know if [`request.response`](https://hapi.dev/api/#request.response) is a hapi response object or a boom error.  Returns `response`.
+
+- `name` - the header name.
+- `value` - the header value.
+- `options` - (optional) object where:
+  - `append` - if `true`, the value is appended to any existing header value using `separator`.  Defaults to `false`.
+  - `separator` - string used as separator when appending to an existing value.  Defaults to `','`.
+  - `override` - if `false`, the header value is not set if an existing value present.  Defaults to `true`.
+  - `duplicate` - if `false`, the header value is not modified if the provided value is already included.  Does not apply when `append` is `false` or if the `name` is `'set-cookie'`.  Defaults to `true`.
+
+### `Toys.getHeaders(response)`
+> As instance, `toys.getHeaders(response)`
+
+Returns `response`'s current HTTP headers, where `response` may be a hapi [response object](https://hapi.dev/api/#response-object) or a [boom](https://hapi.dev/family/boom) error.
+
+### `Toys.code(response, statusCode)`
+> As instance, `toys.code(response, statusCode)`
+
+Designed to behave identically to hapi's [`response.code(statusCode)`](https://hapi.dev/api/#response.code()), but provide a unified interface for setting the HTTP status code between both hapi [response objects](https://hapi.dev/api/#response-object) and [boom](https://hapi.dev/family/boom) errors.  This is useful in request extensions, when you don't know if [`request.response`](https://hapi.dev/api/#request.response) is a hapi response object or a boom error.  Returns `response`.
+
+### `Toys.getCode(response)`
+> As instance, `toys.getCode(response)`
+
+Returns `response`'s current HTTP status code, where `response` may be a hapi [response object](https://hapi.dev/api/#response-object) or a [boom](https://hapi.dev/family/boom) error.
+
 ### `Toys.realm(obj)`
 > As instance, `toys.realm([obj])`
 

--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------
 
 The Toys.reacher() and Toys.transformer() functions are based on code from hoek,
-and the internals.fromString() function is based on code from hapi.  Your use of
+and the Toys.header() function is based on code from hapi.  Your use of
 the source code for these functions is additionally subject to the terms and
 conditions of the following license.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -450,6 +450,103 @@ module.exports = class Toys {
 
         return this.constructor.options(obj);
     }
+
+    static header(response, key, value, options = {}) {
+
+        Hoek.assert(response && (response.isBoom || typeof response.header === 'function'), 'The passed response must be a boom error or hapi response object.');
+
+        if (!response.isBoom) {
+            return response.header(key, value, options);
+        }
+
+        key = key.toLowerCase();
+        const { headers } = response.output;
+
+        const append = options.append || false;
+        const separator = options.separator || ',';
+        const override = options.override !== false;
+        const duplicate = options.duplicate !== false;
+
+        if ((!append && override) || !headers[key]) {
+            headers[key] = value;
+        }
+        else if (override) {
+            if (key === 'set-cookie') {
+                headers[key] = [].concat(headers[key], value);
+            }
+            else {
+                const existing = headers[key];
+                if (!duplicate) {
+                    const values = existing.split(separator);
+                    for (const v of values) {
+                        if (v === value) {
+                            return response;
+                        }
+                    }
+                }
+
+                headers[key] = existing + separator + value;
+            }
+        }
+
+        return response;
+    }
+
+    header(response, key, value, options) {
+
+        return this.constructor.header(response, key, value, options);
+    }
+
+    static getHeaders(response) {
+
+        Hoek.assert(response && (response.isBoom || typeof response.header === 'function'), 'The passed response must be a boom error or hapi response object.');
+
+        if (!response.isBoom) {
+            return response.headers;
+        }
+
+        return response.output.headers;
+    }
+
+    getHeaders(response) {
+
+        return this.constructor.getHeaders(response);
+    }
+
+    static code(response, statusCode) {
+
+        Hoek.assert(response && (response.isBoom || typeof response.code === 'function'), 'The passed response must be a boom error or hapi response object.');
+
+        if (!response.isBoom) {
+            return response.code(statusCode);
+        }
+
+        response.output.statusCode = statusCode;
+        response.reformat();
+
+        return response;
+    }
+
+    code(response, statusCode) {
+
+        return this.constructor.code(response, statusCode);
+    }
+
+    static getCode(response) {
+
+        Hoek.assert(response && (response.isBoom || typeof response.code === 'function'), 'The passed response must be a boom error or hapi response object.');
+
+        if (!response.isBoom) {
+            return response.statusCode;
+        }
+
+        return response.output.statusCode;
+    }
+
+    getCode(response) {
+
+        return this.constructor.getCode(response);
+    }
 };
 
 // Looks like a realm

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@hapi/hoek": "8.x.x"
   },
   "devDependencies": {
+    "@hapi/boom": "7.x.x",
     "@hapi/code": "6.x.x",
     "@hapi/hapi": "18.x.x",
     "@hapi/lab": "20.x.x",


### PR DESCRIPTION
Implements utilities for getting/setting HTTP headers and status code in a unified way across hapi response objects and boom errors.  Resolves #11.