### PR TITLE
Move to @hapipal npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyse
 ```js
 const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
-const Toys = require('toys');
+const Toys = require('@hapipal/toys');
 
 (async () => {
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "toys",
+  "name": "@hapipal/toys",
   "version": "2.3.1",
   "description": "The hapi utility toy chest",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=12"
+  },
   "directories": {
     "test": "test"
   },
@@ -29,6 +32,14 @@
   "homepage": "https://github.com/hapipal/toys#readme",
   "dependencies": {
     "@hapi/hoek": "9.x.x"
+  },
+  "peerDependencies": {
+    "@hapi/hapi": ">=19 <21"
+  },
+  "peerDependenciesMeta": {
+    "@hapi/hapi": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@hapi/boom": "9.x.x",


### PR DESCRIPTION
Closes #24.  Also updates `engines` field and adds hapi as an optional peer.