### PR TITLE
Implement async storage helpers

### DIFF
--- a/API.md
+++ b/API.md
@@ -365,3 +365,30 @@ Returns the plugin state for `pluginName` within `realm`'s [root realm](#toysroo
 ### `Toys.forEachAncestorRealm(realm, fn)`
 
 Walks up the `realm.parent` chain and calls `fn(realm)` for each realm, starting with the passed `realm`.  When used as an instance, this method starts with `toys.server.realm`.
+
+### `Toys.asyncStorage(identifier)`
+
+Returns async local storage store associated with `identifier`, as set-up using [`Toys.withAsyncStorage()`](#toyswithasyncstorageidentifier-store-fn).  When there is no active store, returns `undefined`.
+
+### `Toys.withAsyncStorage(identifier, store, fn)`
+
+Runs and returns the result of `fn` with an active async local storage `store` identified by `identifier`.  Intended to be used with [`Toys.asyncStorage()`](#toysasyncstorageidentifier).  Note that string identifiers beginning with `'@hapipal'` are reserved.
+
+```js
+const multiplyBy = async (x) => {
+
+    await Hoek.wait(10); // Wait 10ms
+
+    return x * (Toys.asyncStorage('y') || 0);
+};
+
+// The result is 4 * 3 = 12
+const result = await Toys.withAsyncStorage('y', 3, async () => {
+
+    return await multiplyBy(4);
+});
+```
+
+### `Toys.asyncStorageInternals()`
+
+Returns a `Map` which maps identifiers utilized by [`Toys.withAsyncStorage()`](#toyswithasyncstorageidentifier-store-fn) to the underlying instances of [`AsyncLocalStorage`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage).

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { AsyncLocalStorage } = require('async_hooks');
 const Hoek = require('@hapi/hoek');
 
 const internals = {};
@@ -387,6 +388,28 @@ exports.getCode = (response) => {
     return response.output.statusCode;
 };
 
+exports.asyncStorage = (identifier) => {
+
+    if (!internals.asyncStorageInternals.has(identifier)) {
+        return;
+    }
+
+    return internals.asyncStorageInternals.get(identifier).getStore();
+};
+
+exports.withAsyncStorage = (identifier, store, fn) => {
+
+    Hoek.assert(typeof exports.asyncStorage(identifier) === 'undefined', `There is already an active async store for identifier "${String(identifier)}".`);
+
+    if (!internals.asyncStorageInternals.has(identifier)) {
+        internals.asyncStorageInternals.set(identifier, new AsyncLocalStorage());
+    }
+
+    return internals.asyncStorageInternals.get(identifier).run(store, fn);
+};
+
+exports.asyncStorageInternals = () => internals.asyncStorageInternals;
+
 // Looks like a realm
 internals.isRealm = (obj) => obj && obj.hasOwnProperty('pluginOptions') && obj.hasOwnProperty('modifiers');
 
@@ -466,3 +489,5 @@ internals.ext = (type, method, options) => {
 
     return extConfig;
 };
+
+internals.asyncStorageInternals = new Map();

--- a/test/index.js
+++ b/test/index.js
@@ -1771,4 +1771,122 @@ describe('Toys', () => {
             expect(res.statusCode).to.equal(403);
         });
     });
+
+    describe('asyncStorage(), withAsyncStorage(), and asyncStorageInternals()', () => {
+
+        it('set-up async local storage based on a string identifier.', async () => {
+
+            const multiplyBy = async (x, ms) => {
+
+                await Hoek.wait(ms);
+
+                return x * (Toys.asyncStorage('y') || 0);
+            };
+
+            const [a, b, c, d] = await Promise.all([
+                Toys.withAsyncStorage('y', 2, async () => await multiplyBy(4, 10)),
+                multiplyBy(4, 20),
+                Toys.withAsyncStorage('y', 4, async () => await multiplyBy(4, 30)),
+                Toys.withAsyncStorage('y', 5, async () => await multiplyBy(4, 40))
+            ]);
+
+            expect(a).to.equal(2 * 4);
+            expect(b).to.equal(0 * 4);
+            expect(c).to.equal(4 * 4);
+            expect(d).to.equal(5 * 4);
+        });
+
+        it('set-up async local storage based on a symbol identifier.', async () => {
+
+            const kY = Symbol('y');
+
+            const multiplyBy = async (x, ms) => {
+
+                await Hoek.wait(ms);
+
+                return x * (Toys.asyncStorage(kY) || 0);
+            };
+
+            const [a, b, c, d] = await Promise.all([
+                Toys.withAsyncStorage(kY, 2, async () => await multiplyBy(4, 10)),
+                multiplyBy(4, 20),
+                Toys.withAsyncStorage(kY, 4, async () => await multiplyBy(4, 30)),
+                Toys.withAsyncStorage(kY, 5, async () => await multiplyBy(4, 40))
+            ]);
+
+            expect(a).to.equal(2 * 4);
+            expect(b).to.equal(0 * 4);
+            expect(c).to.equal(4 * 4);
+            expect(d).to.equal(5 * 4);
+        });
+
+        it('do not allow conflicting async local storage identifiers on the same stack.', async () => {
+
+            const multiplyBy = async (x) => {
+
+                await Hoek.wait(0);
+
+                return x * (Toys.asyncStorage('y') || 0);
+            };
+
+            const getResult = async () => {
+
+                return await Toys.withAsyncStorage('y', 3, async () => {
+
+                    const a = await multiplyBy(4);
+
+                    return await Toys.withAsyncStorage('y', a, async () => {
+
+                        return await multiplyBy(5);
+                    });
+                });
+            };
+
+            await expect(getResult()).to.reject('There is already an active async store for identifier "y".');
+        });
+
+        it('generate errors for Symbols properly.', async () => {
+
+            const kY = Symbol('y');
+
+            const multiplyBy = async (x) => {
+
+                await Hoek.wait(0);
+
+                return x * (Toys.asyncStorage(kY) || 0);
+            };
+
+            const getResult = async () => {
+
+                return await Toys.withAsyncStorage(kY, 3, async () => {
+
+                    const a = await multiplyBy(4);
+
+                    return await Toys.withAsyncStorage(kY, a, async () => {
+
+                        return await multiplyBy(5);
+                    });
+                });
+            };
+
+            await expect(getResult()).to.reject('There is already an active async store for identifier "Symbol(y)".');
+        });
+
+        it('expose async local storage instances.', async () => {
+
+            const multiplyBy = async (x) => {
+
+                await Hoek.wait(0);
+
+                Toys.asyncStorageInternals().get('y').disable();
+
+                return x * (Toys.asyncStorage('y') || 0);
+            };
+
+            const a = await Toys.withAsyncStorage('y', 3, async () => await multiplyBy(4));
+
+            expect(a).to.equal(0);
+            expect(Toys.asyncStorageInternals()).to.be.an.instanceof(Map);
+        });
+    });
 });


### PR DESCRIPTION
Implements, tests, and documents `Toys.asyncStorage()`, `Toys.withAsyncStorage()`, and `Toys.asyncStorageInternals()`, resolving #26.