### PR TITLE
Add ability to patch joi schemas with Toys

### DIFF
--- a/API.md
+++ b/API.md
@@ -402,7 +402,8 @@ Returns a `Map` which maps identifiers utilized by [`Toys.withAsyncStorage()`](#
 Converts a Joi creation schema into a patch schema, ignoring defaults and making all keys optional.
 
 ```js
+// result.name is no longer required
 const result = await Toys.patchJoiSchema(Joi.object().keys({
-    name: Joi.string.required()
+    name: Joi.string().required()
 }));
 ```

--- a/API.md
+++ b/API.md
@@ -403,7 +403,7 @@ Converts a Joi creation schema into a patch schema, ignoring defaults and making
 
 ```js
 // result.name is no longer required
-const result = await Toys.patchJoiSchema(Joi.object().keys({
+const result = Toys.patchJoiSchema(Joi.object().keys({
     name: Joi.string().required()
 }));
 ```

--- a/API.md
+++ b/API.md
@@ -396,3 +396,13 @@ const result = await Toys.withAsyncStorage('y', 3, async () => {
 ### `Toys.asyncStorageInternals()`
 
 Returns a `Map` which maps identifiers utilized by [`Toys.withAsyncStorage()`](#toyswithasyncstorageidentifier-store-fn) to the underlying instances of [`AsyncLocalStorage`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynclocalstorage).
+
+### `Toys.patchJoiSchema(schema)`
+
+Converts a Joi creation schema into a patch schema, ignoring defaults and making all keys optional.
+
+```js
+const result = await Toys.patchJoiSchema(Joi.object().keys({
+    name: Joi.string.required()
+}));
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -447,6 +447,23 @@ exports.withAsyncStorage = (identifier, store, fn) => {
 
 exports.asyncStorageInternals = () => internals.asyncStorageInternals;
 
+exports.patchJoiSchema = (schema) => {
+
+    if (!schema) {
+        return;
+    }
+
+    const keys = Object.keys(schema.describe().keys || {});
+
+    // Make all keys optional, do not enforce defaults
+
+    if (keys.length) {
+        schema = schema.fork(keys, (s) => s.optional());
+    }
+
+    return schema.prefs({ noDefaults: true });
+};
+
 // Looks like a realm
 internals.isRealm = (obj) => obj && obj.hasOwnProperty('pluginOptions') && obj.hasOwnProperty('modifiers');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -449,10 +449,6 @@ exports.asyncStorageInternals = () => internals.asyncStorageInternals;
 
 exports.patchJoiSchema = (schema) => {
 
-    if (!schema) {
-        return;
-    }
-
     const keys = Object.keys(schema.describe().keys || {});
 
     // Make all keys optional, do not enforce defaults

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@hapi/code": "8.x.x",
     "@hapi/hapi": "20.x.x",
     "@hapi/lab": "24.x.x",
-    "coveralls": "3.x.x"
+    "coveralls": "3.x.x",
+    "joi": "17.x.x"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ const Code = require('@hapi/code');
 const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
 const Hoek = require('@hapi/hoek');
+const Joi = require('joi');
 const Toys = require('..');
 
 // Test shortcuts
@@ -1953,6 +1954,37 @@ describe('Toys', () => {
 
             expect(a).to.equal(0);
             expect(Toys.asyncStorageInternals()).to.be.an.instanceof(Map);
+        });
+    });
+
+    describe('joi patch schema', () => {
+
+        it('returns undefined if no schema passed in', () => {
+
+            const result = Toys.patchJoiSchema();
+
+            expect(result).to.equal(undefined);
+        });
+
+        it('returns patched schema for joi object', () => {
+
+            const schema = Joi.object();
+
+            const result = Toys.patchJoiSchema(schema);
+
+            expect(result).to.be.an.object();
+        });
+
+        it('returns patched schema for joi object with keys', () => {
+
+            const schema = Joi.object().keys({
+                a: Joi.string().required(),
+                b: Joi.date()
+            });
+
+            const result = Toys.patchJoiSchema(schema);
+
+            expect(result).to.be.an.object();
         });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1957,14 +1957,8 @@ describe('Toys', () => {
         });
     });
 
-    describe('joi patch schema', () => {
+    describe('patchJoiSchema()', () => {
 
-        it('returns undefined if no schema passed in', () => {
-
-            const result = Toys.patchJoiSchema();
-
-            expect(result).to.equal(undefined);
-        });
 
         it('returns patched schema for joi object', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1959,26 +1959,41 @@ describe('Toys', () => {
 
     describe('patchJoiSchema()', () => {
 
-
         it('returns patched schema for joi object', () => {
 
             const schema = Joi.object();
 
-            const result = Toys.patchJoiSchema(schema);
+            const patchedSchema = Toys.patchJoiSchema(schema);
 
-            expect(result).to.be.an.object();
+            expect(patchedSchema).to.be.an.object();
         });
 
-        it('returns patched schema for joi object with keys', () => {
+        it('patched joi schema contains optional keys', () => {
 
             const schema = Joi.object().keys({
                 a: Joi.string().required(),
-                b: Joi.date()
+                b: Joi.date().required()
             });
 
-            const result = Toys.patchJoiSchema(schema);
+            const patchedSchema = Toys.patchJoiSchema(schema);
+            const described = patchedSchema.describe();
 
-            expect(result).to.be.an.object();
+            expect(described.preferences).to.equal({ noDefaults: true });
+            expect(described.keys.a.flags).to.equal({ presence: 'optional' });
+            expect(described.keys.b.flags).to.equal({ presence: 'optional' });
+        });
+
+        it('patched joi schema does not enforce defaults', () => {
+
+            const schema = Joi.object().keys({
+                x: Joi.number().integer().default(10)
+            });
+
+            const patchedSchema = Toys.patchJoiSchema(schema);
+            const described = patchedSchema.describe();
+
+            expect(described.keys.x.flags).to.equal({ default: 10, presence: 'optional' });
+            expect(patchedSchema.validate({ x: undefined })).to.equal({ value: { x: undefined } });
         });
     });
 });


### PR DESCRIPTION
This PR introduces `Toys.patchJoiSchema` to Toys. This allows us to use Toys to generate patch schemas which seems to be a recurring topic in our Slack community.

A couple of points from me:

1. I've added 3 unit tests so coverage remains 100%. I'm not sure if asserting a result with `to.be.an.object()` is sufficient in this case. Arguably, the returned schema is already tested in joi but happy to amend this if you like.
2. Let me know if the example I've got in [API.md](API.md) isn't clear and I'll amend it too

Cheers 🥂