### PR TITLE
Support node v16+, hapi v20+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 import:
-  - source: hapipal/ci-config-travis:node_js.yml@hapi-v21
-  - source: hapipal/ci-config-travis:hapi_all.yml@hapi-v21
+  - source: hapipal/ci-config-travis:node_js.yml@node-v16-min
+  - source: hapipal/ci-config-travis:hapi_all.yml@node-v16-min

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ The hapi utility toy chest
 
 > **Note**
 >
-> Toys is intended for use with hapi v19+ and nodejs v12+ (_see v2 for lower support_).
+> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v4 for lower support_).
 
 ## `Toys`
 ### `Toys.withRouteDefaults(defaults)`

--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@ The hapi utility toy chest
 
 > **Note**
 >
-> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v4 for lower support_).
+> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v3 for lower support_).
 
 ## `Toys`
 ### `Toys.withRouteDefaults(defaults)`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2022 Devin Ivy
+Copyright (c) 2017-2022 Devin Ivy and project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @hapipal/toys
 ## Usage
 > See also the [API Reference](API.md)
 >
-> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v4 for lower support_).
+> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v3 for lower support_).
 
 Toys is a collection of utilities made to reduce common boilerplate in **hapi v20+** projects, aid usage of events and streams in `async` functions (e.g. handlers and server methods), and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ npm install @hapipal/toys
 ## Usage
 > See also the [API Reference](API.md)
 >
-> Toys is intended for use with hapi v19+ and nodejs v12+ (_see v2 for lower support_).
+> Toys is intended for use with hapi v20+ and nodejs v16+ (_see v4 for lower support_).
 
-Toys is a collection of utilities made to reduce common boilerplate in **hapi v19+** projects, aid usage of events and streams in `async` functions (e.g. handlers and server methods), and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
+Toys is a collection of utilities made to reduce common boilerplate in **hapi v20+** projects, aid usage of events and streams in `async` functions (e.g. handlers and server methods), and provide versions of widely-used utilities from [Hoek](https://github.com/hapijs/hoek) optimized to perform well in hot code paths such as route handlers.
 
 Below is an example featuring [`Toys.auth.strategy()`](API.md#toysauthstrategyserver-name-authenticate), [`Toys.reacher()`](API.md#toysreacherchain-options), and [`Toys.withRouteDefaults()`](API.md#toyswithroutedefaultsdefaults).  The [API Reference](API.md) is also filled with examples.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "directories": {
     "test": "test"
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/hapipal/toys#readme",
   "dependencies": {
-    "@hapi/hoek": "^9.0.0"
+    "@hapi/hoek": "^11.0.2"
   },
   "peerDependencies": {
-    "@hapi/hapi": ">=19 <22"
+    "@hapi/hapi": ">=20 <22"
   },
   "peerDependenciesMeta": {
     "@hapi/hapi": {
@@ -43,10 +43,10 @@
     }
   },
   "devDependencies": {
-    "@hapi/boom": "^9.0.0",
-    "@hapi/code": "^8.0.0",
-    "@hapi/hapi": "^20.0.0",
-    "@hapi/lab": "^24.0.0",
+    "@hapi/boom": "^10.0.0",
+    "@hapi/code": "^9.0.2",
+    "@hapi/hapi": "^21.2.1",
+    "@hapi/lab": "^25.1.0",
     "coveralls": "^3.0.0",
     "joi": "^17.0.0"
   }

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Toys;
+
+    before(async () => {
+
+        Toys = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Toys)).to.equal([
+            'asyncStorage',
+            'asyncStorageInternals',
+            'auth',
+            'code',
+            'default',
+            'event',
+            'ext',
+            'forEachAncestorRealm',
+            'getCode',
+            'getHeaders',
+            'header',
+            'noop',
+            'onCredentials',
+            'onPostAuth',
+            'onPostHandler',
+            'onPostStart',
+            'onPostStop',
+            'onPreAuth',
+            'onPreHandler',
+            'onPreResponse',
+            'onPreStart',
+            'onPreStop',
+            'onRequest',
+            'options',
+            'patchJoiSchema',
+            'pre',
+            'reacher',
+            'realm',
+            'rootRealm',
+            'rootState',
+            'state',
+            'stream',
+            'transformer',
+            'withAsyncStorage',
+            'withRouteDefaults'
+        ]);
+    });
+});


### PR DESCRIPTION
Dropping support for node v12 and v14, the latter of which will be EOL shortly, and hapi v19.  Adds official support for node 18.  Also updates dependencies and tests ESM exports.